### PR TITLE
Added AVX2 support in PoW processing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,14 +37,14 @@ install:
   - rm lin64/libccurl.so
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     echo "in linux";
-    gcc -shared -o libccurl.so libccurl.cpp -O3 -lpthread -fPIC -std=c++11;
+    gcc -shared -o libccurl.so libccurl.cpp -O3 -lpthread -fPIC -std=c++11 -mavx2;
     mkdir -p lin64;
     cp libccurl.so lin64/;
     rm libccurl.so;
     fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     echo "in osx";
-    gcc -dynamiclib -o libccurl.dylib libccurl.cpp -O3 -lpthread -std=c++11;
+    gcc -dynamiclib -o libccurl.dylib libccurl.cpp -O3 -lpthread -std=c++11 -mavx2;
     mkdir -p mac;
     cp libccurl.dylib mac/;
     rm libccurl.dylib;

--- a/ccurl/libccurl.cpp
+++ b/ccurl/libccurl.cpp
@@ -28,7 +28,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <time.h>
+#include <sys/time.h>
 #include <stddef.h>
 
 #ifdef _MSC_VER
@@ -64,31 +64,34 @@ pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 #define HBITS 0xFFFFFFFFFFFFFFFFuLL
 #define LBITS 0x0000000000000000uLL
 #define HASH_LENGTH 243 //trits
-#define STATE_LENGTH 3 * HASH_LENGTH //trits
-#define HALF_LENGTH 364 //trits
+#define STATE_LENGTH 3 * HASH_LENGTH //trits : 729
 #define TX_LENGTH 2673 //trytes
 
-#define LOW00 0xDB6DB6DB6DB6DB6DuLL //0b1101101101101101101101101101101101101101101101101101101101101101L;
-#define HIGH00 0xB6DB6DB6DB6DB6DBuLL //0b1011011011011011011011011011011011011011011011011011011011011011L;
-#define LOW10 0xF1F8FC7E3F1F8FC7uLL //0b1111000111111000111111000111111000111111000111111000111111000111L;
-#define HIGH10 0x8FC7E3F1F8FC7E3FuLL //0b1000111111000111111000111111000111111000111111000111111000111111L;
-#define LOW20 0x7FFFE00FFFFC01FFuLL //0b0111111111111111111000000000111111111111111111000000000111111111L;
-#define HIGH20 0xFFC01FFFF803FFFFuLL //0b1111111111000000000111111111111111111000000000111111111111111111L;
-#define LOW30 0xFFC0000007FFFFFFuLL //0b1111111111000000000000000000000000000111111111111111111111111111L;
-#define HIGH30 0x003FFFFFFFFFFFFFuLL //0b0000000000111111111111111111111111111111111111111111111111111111L;
-#define LOW40 0xFFFFFFFFFFFFFFFFuLL //0b1111111111111111111111111111111111111111111111111111111111111111L;
-#define HIGH40 0xFFFFFFFFFFFFFFFFuLL //0b1111111111111111111111111111111111111111111111111111111111111111L;
+#define LO00 0xDB6DB6DB6DB6DB6DuLL //0b1101101101101101101101101101101101101101101101101101101101101101L;
+#define HI00 0xB6DB6DB6DB6DB6DBuLL //0b1011011011011011011011011011011011011011011011011011011011011011L;
+#define LO10 0xF1F8FC7E3F1F8FC7uLL //0b1111000111111000111111000111111000111111000111111000111111000111L;
+#define HI10 0x8FC7E3F1F8FC7E3FuLL //0b1000111111000111111000111111000111111000111111000111111000111111L;
+#define LO20 0x7FFFE00FFFFC01FFuLL //0b0111111111111111111000000000111111111111111111000000000111111111L;
+#define HI20 0xFFC01FFFF803FFFFuLL //0b1111111111000000000111111111111111111000000000111111111111111111L;
+#define LO30 0xFFC0000007FFFFFFuLL //0b1111111111000000000000000000000000000111111111111111111111111111L;
+#define HI30 0x003FFFFFFFFFFFFFuLL //0b0000000000111111111111111111111111111111111111111111111111111111L;
+#define LO40 0xFFFFFFFFFFFFFFFFuLL //0b1111111111111111111111111111111111111111111111111111111111111111L;
+#define HI40 0xFFFFFFFFFFFFFFFFuLL //0b1111111111111111111111111111111111111111111111111111111111111111L;
 
-#define LOW01 0x6DB6DB6DB6DB6DB6uLL //0b0110110110110110110110110110110110110110110110110110110110110110
-#define HIGH01 0xDB6DB6DB6DB6DB6DuLL //0b1101101101101101101101101101101101101101101101101101101101101101
-#define LOW11 0xF8FC7E3F1F8FC7E3uLL //0b1111100011111100011111100011111100011111100011111100011111100011
-#define HIGH11 0xC7E3F1F8FC7E3F1FuLL //0b1100011111100011111100011111100011111100011111100011111100011111
-#define LOW21 0xC01FFFF803FFFF00uLL //0b1100000000011111111111111111100000000011111111111111111100000000
-#define HIGH21 0x3FFFF007FFFE00FFuLL //0b0011111111111111111100000000011111111111111111100000000011111111
-#define LOW31 0x00000FFFFFFFFFFFuLL //0b0000000000000000000011111111111111111111111111111111111111111111
-#define HIGH31 0xFFFFFFFFFFFE0000uLL //0b1111111111111111111111111111111111111111111111100000000000000000
-#define LOW41 0x000000000001FFFFuLL //0b0000000000000000000000000000000000000000000000011111111111111111
-#define HIGH41 0xFFFFFFFFFFFFFFFFuLL //0b1111111111111111111111111111111111111111111111111111111111111111
+#define LO01 0x6DB6DB6DB6DB6DB6uLL //0b0110110110110110110110110110110110110110110110110110110110110110
+#define HI01 0xDB6DB6DB6DB6DB6DuLL //0b1101101101101101101101101101101101101101101101101101101101101101
+#define LO11 0xF8FC7E3F1F8FC7E3uLL //0b1111100011111100011111100011111100011111100011111100011111100011
+#define HI11 0xC7E3F1F8FC7E3F1FuLL //0b1100011111100011111100011111100011111100011111100011111100011111
+#define LO21 0xC01FFFF803FFFF00uLL //0b1100000000011111111111111111100000000011111111111111111100000000
+#define HI21 0x3FFFF007FFFE00FFuLL //0b0011111111111111111100000000011111111111111111100000000011111111
+#define LO31 0x00000FFFFFFFFFFFuLL //0b0000000000000000000011111111111111111111111111111111111111111111
+#define HI31 0xFFFFFFFFFFFE0000uLL //0b1111111111111111111111111111111111111111111111100000000000000000
+#define LO41 0x000000000001FFFFuLL //0b0000000000000000000000000000000000000000000000011111111111111111
+#define HI41 0xFFFFFFFFFFFFFFFFuLL //0b1111111111111111111111111111111111111111111111111111111111111111
+
+// loop_cpu index
+#define L_IDX 0
+#define H_IDX 1
 
 #ifndef EXPORT
 #if defined(_WIN32) || defined(_MSC_VER)
@@ -117,6 +120,7 @@ extern "C"{
 
 int getCpuNum()
 {
+    //return 1;// TODO debug
 #if defined(__linux) || defined(__APPLE__)
     // for linux
     return sysconf(_SC_NPROCESSORS_ONLN);
@@ -128,14 +132,71 @@ int getCpuNum()
 #endif
 }
 
+// TODO implement
+bool hasAvx(int n)
+{
+    bool avx;
+#ifdef HAS_AVX
+    avx = true;
+#else
+    avx = false;
+#endif
+    if (n == 1) {
+        printf("avx %d\n", avx);
+    }
+    return avx;
+}
+
 const int indices[] = {
-    0, 364, 728, 363, 727, 362, 726, 361, 725, 360, 724, 359, 723, 358, 722, 357, 721, 356, 720, 355, 719, 354, 718, 353, 717, 352, 716, 351, 715, 350, 714, 349, 713, 348, 712, 347, 711, 346, 710, 345, 709, 344, 708, 343, 707, 342, 706, 341, 705, 340, 704, 339, 703, 338, 702, 337, 701, 336, 700, 335, 699, 334, 698, 333, 697, 332, 696, 331, 695, 330, 694, 329, 693, 328, 692, 327, 691, 326, 690, 325, 689, 324, 688, 323, 687, 322, 686, 321, 685, 320, 684, 319, 683, 318, 682, 317, 681, 316, 680, 315, 679, 314, 678, 313, 677, 312, 676, 311, 675, 310, 674, 309, 673, 308, 672, 307, 671, 306, 670, 305, 669, 304, 668, 303, 667, 302, 666, 301, 665, 300, 664, 299, 663, 298, 662, 297, 661, 296, 660, 295, 659, 294, 658, 293, 657, 292, 656, 291, 655, 290, 654, 289, 653, 288, 652, 287, 651, 286, 650, 285, 649, 284, 648, 283, 647, 282, 646, 281, 645, 280, 644, 279, 643, 278, 642, 277, 641, 276, 640, 275, 639, 274, 638, 273, 637, 272, 636, 271, 635, 270, 634, 269, 633, 268, 632, 267, 631, 266, 630, 265, 629, 264, 628, 263, 627, 262, 626, 261, 625, 260, 624, 259, 623, 258, 622, 257, 621, 256, 620, 255, 619, 254, 618, 253, 617, 252, 616, 251, 615, 250, 614, 249, 613, 248, 612, 247, 611, 246, 610, 245, 609, 244, 608, 243, 607, 242, 606, 241, 605, 240, 604, 239, 603, 238, 602, 237, 601, 236, 600, 235, 599, 234, 598, 233, 597, 232, 596, 231, 595, 230, 594, 229, 593, 228, 592, 227, 591, 226, 590, 225, 589, 224, 588, 223, 587, 222, 586, 221, 585, 220, 584, 219, 583, 218, 582, 217, 581, 216, 580, 215, 579, 214, 578, 213, 577, 212, 576, 211, 575, 210, 574, 209, 573, 208, 572, 207, 571, 206, 570, 205, 569, 204, 568, 203, 567, 202, 566, 201, 565, 200, 564, 199, 563, 198, 562, 197, 561, 196, 560, 195, 559, 194, 558, 193, 557, 192, 556, 191, 555, 190, 554, 189, 553, 188, 552, 187, 551, 186, 550, 185, 549, 184, 548, 183, 547, 182, 546, 181, 545, 180, 544, 179, 543, 178, 542, 177, 541, 176, 540, 175, 539, 174, 538, 173, 537, 172, 536, 171, 535, 170, 534, 169, 533, 168, 532, 167, 531, 166, 530, 165, 529, 164, 528, 163, 527, 162, 526, 161, 525, 160, 524, 159, 523, 158, 522, 157, 521, 156, 520, 155, 519, 154, 518, 153, 517, 152, 516, 151, 515, 150, 514, 149, 513, 148, 512, 147, 511, 146, 510, 145, 509, 144, 508, 143, 507, 142, 506, 141, 505, 140, 504, 139, 503, 138, 502, 137, 501, 136, 500, 135, 499, 134, 498, 133, 497, 132, 496, 131, 495, 130, 494, 129, 493, 128, 492, 127, 491, 126, 490, 125, 489, 124, 488, 123, 487, 122, 486, 121, 485, 120, 484, 119, 483, 118, 482, 117, 481, 116, 480, 115, 479, 114, 478, 113, 477, 112, 476, 111, 475, 110, 474, 109, 473, 108, 472, 107, 471, 106, 470, 105, 469, 104, 468, 103, 467, 102, 466, 101, 465, 100, 464, 99, 463, 98, 462, 97, 461, 96, 460, 95, 459, 94, 458, 93, 457, 92, 456, 91, 455, 90, 454, 89, 453, 88, 452, 87, 451, 86, 450, 85, 449, 84, 448, 83, 447, 82, 446, 81, 445, 80, 444, 79, 443, 78, 442, 77, 441, 76, 440, 75, 439, 74, 438, 73, 437, 72, 436, 71, 435, 70, 434, 69, 433, 68, 432, 67, 431, 66, 430, 65, 429, 64, 428, 63, 427, 62, 426, 61, 425, 60, 424, 59, 423, 58, 422, 57, 421, 56, 420, 55, 419, 54, 418, 53, 417, 52, 416, 51, 415, 50, 414, 49, 413, 48, 412, 47, 411, 46, 410, 45, 409, 44, 408, 43, 407, 42, 406, 41, 405, 40, 404, 39, 403, 38, 402, 37, 401, 36, 400, 35, 399, 34, 398, 33, 397, 32, 396, 31, 395, 30, 394, 29, 393, 28, 392, 27, 391, 26, 390, 25, 389, 24, 388, 23, 387, 22, 386, 21, 385, 20, 384, 19, 383, 18, 382, 17, 381, 16, 380, 15, 379, 14, 378, 13, 377, 12, 376, 11, 375, 10, 374, 9, 373, 8, 372, 7, 371, 6, 370, 5, 369, 4, 368, 3, 367, 2, 366, 1, 365, 0
+    //0    1    2    3    4    5    6    7    8    9    0    1    2    3    4    5    6    7    8    9
+      0, 364, 728, 363, 727, 362, 726, 361, 725, 360, 724, 359, 723, 358, 722, 357, 721, 356, 720, 355, //  20
+    719, 354, 718, 353, 717, 352, 716, 351, 715, 350, 714, 349, 713, 348, 712, 347, 711, 346, 710, 345, //  40
+    709, 344, 708, 343, 707, 342, 706, 341, 705, 340, 704, 339, 703, 338, 702, 337, 701, 336, 700, 335, //  60
+    699, 334, 698, 333, 697, 332, 696, 331, 695, 330, 694, 329, 693, 328, 692, 327, 691, 326, 690, 325, //  80
+    689, 324, 688, 323, 687, 322, 686, 321, 685, 320, 684, 319, 683, 318, 682, 317, 681, 316, 680, 315, // 100
+    679, 314, 678, 313, 677, 312, 676, 311, 675, 310, 674, 309, 673, 308, 672, 307, 671, 306, 670, 305, // 120
+    669, 304, 668, 303, 667, 302, 666, 301, 665, 300, 664, 299, 663, 298, 662, 297, 661, 296, 660, 295, // 140
+    659, 294, 658, 293, 657, 292, 656, 291, 655, 290, 654, 289, 653, 288, 652, 287, 651, 286, 650, 285, // 160
+    649, 284, 648, 283, 647, 282, 646, 281, 645, 280, 644, 279, 643, 278, 642, 277, 641, 276, 640, 275, // 180
+    639, 274, 638, 273, 637, 272, 636, 271, 635, 270, 634, 269, 633, 268, 632, 267, 631, 266, 630, 265, // 200
+    629, 264, 628, 263, 627, 262, 626, 261, 625, 260, 624, 259, 623, 258, 622, 257, 621, 256, 620, 255, // 220
+    619, 254, 618, 253, 617, 252, 616, 251, 615, 250, 614, 249, 613, 248, 612, 247, 611, 246, 610, 245, // 240
+    609, 244, 608, 243, 607, 242, 606, 241, 605, 240, 604, 239, 603, 238, 602, 237, 601, 236, 600, 235, // 260
+    599, 234, 598, 233, 597, 232, 596, 231, 595, 230, 594, 229, 593, 228, 592, 227, 591, 226, 590, 225, // 280
+    589, 224, 588, 223, 587, 222, 586, 221, 585, 220, 584, 219, 583, 218, 582, 217, 581, 216, 580, 215, // 300
+    579, 214, 578, 213, 577, 212, 576, 211, 575, 210, 574, 209, 573, 208, 572, 207, 571, 206, 570, 205, // 320
+    569, 204, 568, 203, 567, 202, 566, 201, 565, 200, 564, 199, 563, 198, 562, 197, 561, 196, 560, 195, // 340
+    559, 194, 558, 193, 557, 192, 556, 191, 555, 190, 554, 189, 553, 188, 552, 187, 551, 186, 550, 185, // 360
+    549, 184, 548, 183, 547, 182, 546, 181, 545, 180, 544, 179, 543, 178, 542, 177, 541, 176, 540, 175, // 380
+    539, 174, 538, 173, 537, 172, 536, 171, 535, 170, 534, 169, 533, 168, 532, 167, 531, 166, 530, 165, // 400
+    529, 164, 528, 163, 527, 162, 526, 161, 525, 160, 524, 159, 523, 158, 522, 157, 521, 156, 520, 155, // 420
+    519, 154, 518, 153, 517, 152, 516, 151, 515, 150, 514, 149, 513, 148, 512, 147, 511, 146, 510, 145, // 440
+    509, 144, 508, 143, 507, 142, 506, 141, 505, 140, 504, 139, 503, 138, 502, 137, 501, 136, 500, 135, // 460
+    499, 134, 498, 133, 497, 132, 496, 131, 495, 130, 494, 129, 493, 128, 492, 127, 491, 126, 490, 125, // 480
+    489, 124, 488, 123, 487, 122, 486, 121, 485, 120, 484, 119, 483, 118, 482, 117, 481, 116, 480, 115, // 500
+    479, 114, 478, 113, 477, 112, 476, 111, 475, 110, 474, 109, 473, 108, 472, 107, 471, 106, 470, 105, // 520
+    469, 104, 468, 103, 467, 102, 466, 101, 465, 100, 464,  99, 463,  98, 462,  97, 461,  96, 460,  95, // 540
+    459,  94, 458,  93, 457,  92, 456,  91, 455,  90, 454,  89, 453,  88, 452,  87, 451,  86, 450,  85, // 560
+    449,  84, 448,  83, 447,  82, 446,  81, 445,  80, 444,  79, 443,  78, 442,  77, 441,  76, 440,  75, // 580
+    439,  74, 438,  73, 437,  72, 436,  71, 435,  70, 434,  69, 433,  68, 432,  67, 431,  66, 430,  65, // 600
+    429,  64, 428,  63, 427,  62, 426,  61, 425,  60, 424,  59, 423,  58, 422,  57, 421,  56, 420,  55, // 620
+    419,  54, 418,  53, 417,  52, 416,  51, 415,  50, 414,  49, 413,  48, 412,  47, 411,  46, 410,  45, // 640
+    409,  44, 408,  43, 407,  42, 406,  41, 405,  40, 404,  39, 403,  38, 402,  37, 401,  36, 400,  35, // 660
+    399,  34, 398,  33, 397,  32, 396,  31, 395,  30, 394,  29, 393,  28, 392,  27, 391,  26, 390,  25, // 680
+    389,  24, 388,  23, 387,  22, 386,  21, 385,  20, 384,  19, 383,  18, 382,  17, 381,  16, 380,  15, // 700
+    379,  14, 378,  13, 377,  12, 376,  11, 375,  10, 374,   9, 373,   8, 372,   7, 371,   6, 370,   5, // 720
+    369,   4, 368,   3, 367,   2, 366,   1, 365,   0  // 730
 };
 
 const char truthTable[] = { 1, 0, -1, 0, 1, -1, 0, 0, -1, 1, 0 };
 
 const char tryte2trit_table[][3] = {
-    { 0, 0, 0 }, { 1, 0, 0 }, { -1, 1, 0 }, { 0, 1, 0 }, { 1, 1, 0 }, { -1, -1, 1 }, { 0, -1, 1 }, { 1, -1, 1 }, { -1, 0, 1 }, { 0, 0, 1 }, { 1, 0, 1 }, { -1, 1, 1 }, { 0, 1, 1 }, { 1, 1, 1 }, { -1, -1, -1 }, { 0, -1, -1 }, { 1, -1, -1 }, { -1, 0, -1 }, { 0, 0, -1 }, { 1, 0, -1 }, { -1, 1, -1 }, { 0, 1, -1 }, { 1, 1, -1 }, { -1, -1, 0 }, { 0, -1, 0 }, { 1, -1, 0 }, { -1, 0, 0 }
+    {  0,  0,  0 }, {  1,  0,  0 }, { -1,  1,  0 }, {  0,  1,  0 }, {  1,  1,  0 }, //  5
+    { -1, -1,  1 }, {  0, -1,  1 }, {  1, -1,  1 }, { -1,  0,  1 }, {  0,  0,  1 }, // 10
+    {  1,  0,  1 }, { -1,  1,  1 }, {  0,  1,  1 }, {  1,  1,  1 }, { -1, -1, -1 }, // 15
+    {  0, -1, -1 }, {  1, -1, -1 }, { -1,  0, -1 }, {  0,  0, -1 }, {  1,  0, -1 }, // 20
+    { -1,  1, -1 }, {  0,  1, -1 }, {  1,  1, -1 }, { -1, -1,  0 }, {  0, -1,  0 }, // 25
+    {  1, -1,  0 }, { -1,  0,  0 } // 27
 };
 
 static int stop = 0, running = 0;
@@ -253,6 +314,118 @@ void transform64(__m128i* lmid, __m128i* hmid)
      }
 }
 
+void transform64_AVX(
+    // dim 1 Lo/Hi, 2 from/to 
+    __m128i lhmid[2][2][STATE_LENGTH])  // immutable
+{
+    // switcher
+    int from = 0;
+    int to = !from;
+
+    int j, r, t1, t2, t3;
+
+    __m256i one = _mm256_set_epi64x(HBITS, HBITS, HBITS, HBITS);
+    __m256i alpha, beta, gamma, epsilon, delta, nalpha, ltemp, htemp, index;
+    
+    for (r = 0; r < 26; r++) {
+        for (j = 0; j < STATE_LENGTH-1; j+=2) {
+            t1 = indices[j];
+            t2 = indices[j + 1];
+            t3 = indices[j + 2];
+
+            // too slowly gather lol
+            //index = _mm256_set_epi64x(
+            //    (L_IDX * 2 * STATE_LENGTH + from * STATE_LENGTH + t1) * 2 + 1,
+            //    (L_IDX * 2 * STATE_LENGTH + from * STATE_LENGTH + t1) * 2,
+            //    (L_IDX * 2 * STATE_LENGTH + from * STATE_LENGTH + t2) * 2 + 1,
+            //    (L_IDX * 2 * STATE_LENGTH + from * STATE_LENGTH + t2) * 2
+            //);
+            //alpha = _mm256_i64gather_epi64(lhmid, index, 8);
+
+            alpha = _mm256_set_m128i(lhmid[L_IDX][from][t1], lhmid[L_IDX][from][t2]);
+
+            epsilon = _mm256_set_m128i(lhmid[L_IDX][from][t2], lhmid[L_IDX][from][t3]);
+
+            beta = _mm256_set_m128i(lhmid[H_IDX][from][t1], lhmid[H_IDX][from][t2]);
+            gamma = _mm256_set_m128i(lhmid[H_IDX][from][t2], lhmid[H_IDX][from][t3]);
+
+            // (alpha | (~gamma)) & (epsilon ^ beta);
+            nalpha = _mm256_andnot_si256(alpha, gamma);
+            delta = _mm256_andnot_si256(nalpha, _mm256_xor_si256(epsilon, beta)); 
+
+            ltemp = _mm256_andnot_si256(delta, one);  // ~delta;
+            htemp = _mm256_or_si256(_mm256_xor_si256(alpha, gamma), delta); // (alpha ^ gamma) | delta;
+
+            _mm256_storeu2_m128i(&lhmid[L_IDX][to][j], &lhmid[L_IDX][to][j+1], ltemp);
+            _mm256_storeu2_m128i(&lhmid[H_IDX][to][j], &lhmid[H_IDX][to][j+1], htemp);
+        }
+
+        // loop end
+        t1 = indices[STATE_LENGTH-1];
+        t2 = indices[STATE_LENGTH];
+
+        alpha = _mm256_zextsi128_si256(lhmid[L_IDX][from][t1]);
+        epsilon = _mm256_zextsi128_si256(lhmid[L_IDX][from][t2]);
+        beta = _mm256_zextsi128_si256(lhmid[H_IDX][from][t1]);
+        gamma = _mm256_zextsi128_si256(lhmid[H_IDX][from][t2]);
+
+        // (alpha | (~gamma)) & (epsilon ^ beta);
+        nalpha = _mm256_andnot_si256(alpha, gamma);
+        delta = _mm256_andnot_si256(nalpha, _mm256_xor_si256(epsilon, beta)); 
+
+        ltemp = _mm256_andnot_si256(delta, one);  // ~delta;
+        htemp = _mm256_or_si256(_mm256_xor_si256(alpha, gamma), delta); // (alpha ^ gamma) | delta;
+
+        lhmid[L_IDX][to][STATE_LENGTH-1] = _mm256_extractf128_si256(ltemp, 0);
+        lhmid[H_IDX][to][STATE_LENGTH-1] = _mm256_extractf128_si256(htemp, 0);
+
+        // switch side
+        from = !from;
+        to = !to;
+    }
+
+    for (j = 0; j < HASH_LENGTH-1; j+=2) {
+        t1 = indices[j];
+        t2 = indices[j + 1];
+        t3 = indices[j + 2];
+
+        alpha = _mm256_set_m128i(lhmid[L_IDX][from][t1], lhmid[L_IDX][from][t2]);
+        epsilon = _mm256_set_m128i(lhmid[L_IDX][from][t2], lhmid[L_IDX][from][t3]);
+
+        beta = _mm256_set_m128i(lhmid[H_IDX][from][t1], lhmid[H_IDX][from][t2]);
+        gamma = _mm256_set_m128i(lhmid[H_IDX][from][t2], lhmid[H_IDX][from][t3]);
+
+        //(alpha | (~gamma)) & (lfrom[t2] ^ beta);
+        nalpha = _mm256_andnot_si256(alpha, gamma);
+        delta = _mm256_andnot_si256(nalpha, _mm256_xor_si256(epsilon, beta));
+
+        ltemp = _mm256_andnot_si256(delta, one);  //~delta;
+        htemp = _mm256_or_si256(_mm256_xor_si256(alpha, gamma), delta); //(alpha ^ gamma) | delta;
+
+        _mm256_storeu2_m128i(&lhmid[L_IDX][to][j], &lhmid[L_IDX][to][j+1], ltemp);
+        _mm256_storeu2_m128i(&lhmid[H_IDX][to][j], &lhmid[H_IDX][to][j+1], htemp);
+    }
+
+    // loop end
+    t1 = indices[HASH_LENGTH-1];
+    t2 = indices[HASH_LENGTH];
+
+    alpha = _mm256_zextsi128_si256(lhmid[L_IDX][from][t1]);
+    epsilon = _mm256_zextsi128_si256(lhmid[L_IDX][from][t2]);
+    beta = _mm256_zextsi128_si256(lhmid[H_IDX][from][t1]);
+    gamma = _mm256_zextsi128_si256(lhmid[H_IDX][from][t2]);
+
+    // (alpha | (~gamma)) & (epsilon ^ beta);
+    nalpha = _mm256_andnot_si256(alpha, gamma);
+    delta = _mm256_andnot_si256(nalpha, _mm256_xor_si256(epsilon, beta)); 
+
+    ltemp = _mm256_andnot_si256(delta, one);  // ~delta;
+    htemp = _mm256_or_si256(_mm256_xor_si256(alpha, gamma), delta); // (alpha ^ gamma) | delta;
+
+    lhmid[L_IDX][to][HASH_LENGTH-1] = _mm256_extractf128_si256(ltemp, 0);
+    lhmid[H_IDX][to][HASH_LENGTH-1] = _mm256_extractf128_si256(htemp, 0);
+}
+
 int incr(__m128i* mid_low, __m128i* mid_high)
 {
     int i;
@@ -266,6 +439,59 @@ int incr(__m128i* mid_low, __m128i* mid_high)
        _mm_store_si128 ((__m128i*)c,carry);
     }
     return i == HASH_LENGTH;
+}
+
+int incr_AVX(
+    __m128i mid_lo[STATE_LENGTH],  // mutable
+    __m128i mid_hi[STATE_LENGTH]) // mutable
+{
+    __m256i mlo, mhi, carry, hxl;
+
+    // count 5 and 6
+    mlo = _mm256_set_m128i(mid_lo[6], mid_lo[5]);
+    mhi = _mm256_set_m128i(mid_hi[6], mid_hi[5]);
+    carry = _mm256_andnot_si256(mlo, mhi);
+
+    // set count 5
+    hxl = _mm256_xor_si256(mhi, mlo);
+    mid_lo[5] = _mm256_extractf128_si256(hxl, 0);
+    mid_hi[5] = _mm256_extractf128_si256(mlo, 0);
+
+    // check count 5 carry at count 6 start
+    if (!_mm256_extract_epi64(carry, 0)) {
+        return 0;
+    }
+
+    // set count 6
+    mid_lo[6] = _mm256_extractf128_si256(hxl, 1);    
+    mid_hi[6] = _mm256_extractf128_si256(mlo, 1);
+
+    // 7 to HASH_LENGTH-1(242)
+    for (int i = 7; i < HASH_LENGTH; i+=2) {
+
+        // check before cycle count+1 carry 
+        if (!_mm256_extract_epi64(carry, 2)) {
+            return 0;
+        }
+
+        mlo = _mm256_set_m128i(mid_lo[i+1], mid_lo[i]);
+        mhi = _mm256_set_m128i(mid_hi[i+1], mid_hi[i]);
+        carry = _mm256_andnot_si256(mlo, mhi);
+
+        if (!_mm256_extract_epi64(carry, 0)) {
+            // update i 
+            mid_lo[i] = _mm256_extracti128_si256(_mm256_xor_si256(mhi, mlo), 0);
+            mid_hi[i] = _mm256_extracti128_si256(mlo, 0);
+
+            return 0;
+        }
+        
+        // update i, i+1
+        _mm256_storeu2_m128i(&mid_lo[i+1], &mid_lo[i], _mm256_xor_si256(mhi, mlo));
+        _mm256_storeu2_m128i(&mid_hi[i+1], &mid_hi[i], mlo);
+    }
+
+    return 1;
 }
 
 void seri(__m128i* low, __m128i* high, int n, char* r)
@@ -349,6 +575,64 @@ int check(__m128i* l, __m128i* h, int m)
     return -2;
 }
 
+int check_AVX(
+    __m128i ltrans[STATE_LENGTH],   // immutable
+    __m128i htrans[STATE_LENGTH],   // immutable
+    int m)
+{
+    int check;
+    __m256i ltrans256, htrans256, lhxor, lhxor_r, nonce_probe_p1, nonce_probe_p2;
+    __m128i nonce_probe_p1_h, nonce_probe_p2_h, check128;
+
+    __m256i hbits_256i = _mm256_set_epi64x(HBITS, HBITS, HBITS, HBITS);
+    __m256i nonce_probe =  _mm256_set_epi64x(LBITS, LBITS, HBITS, HBITS);
+
+    for (int i = HASH_LENGTH - m; i < HASH_LENGTH; i=i+2) {
+
+        ltrans256 = _mm256_set_m128i(ltrans[i+1], ltrans[i]);
+        htrans256 = _mm256_set_m128i(htrans[i+1], htrans[i]);
+        lhxor = _mm256_xor_si256(ltrans256, htrans256);
+
+        // cycle1
+        nonce_probe_p1 = _mm256_andnot_si256(lhxor, nonce_probe);
+        nonce_probe_p1_h = _mm256_extracti128_si256(nonce_probe_p1, 0);
+
+        check = _mm256_testz_si256(_mm256_set_m128i(nonce_probe_p1_h, nonce_probe_p1_h), hbits_256i);
+        if (check) {
+            return -1;
+        }
+
+        // switch filter
+        // TODO optimize
+        lhxor_r = _mm256_set_m128i(_mm256_extracti128_si256(lhxor, 0), _mm256_extracti128_si256(lhxor, 1));        
+
+        // cycle2
+        nonce_probe_p2 = _mm256_andnot_si256(lhxor_r, nonce_probe_p1);
+        nonce_probe_p2_h = _mm256_extracti128_si256(nonce_probe_p2, 0);
+
+        check = _mm256_testz_si256(_mm256_set_m128i(nonce_probe_p2_h, nonce_probe_p2_h), hbits_256i);
+        if (check) {
+            return -1;
+        }
+
+        // next cycle
+        nonce_probe = _mm256_set_m128i(nonce_probe_p1_h, nonce_probe_p2_h);
+    }
+
+    check128 = _mm256_extracti128_si256(nonce_probe, 1);
+
+    // TODO optimize to SIMD
+    for (int i = 0; i < 64; i++) {
+        if ((check128[0] >> i) & 1) {
+            return i + 0 * 64;
+        }
+        if ((check128[1] >> i) & 1) {
+            return i + 1 * 64;
+        }
+    }
+    return -2;
+}
+
 long long int loop_cpu(__m128i* lmid, __m128i* hmid, int m, char* nonce)
 {
     int n = 0, j = 0;
@@ -365,6 +649,35 @@ long long int loop_cpu(__m128i* lmid, __m128i* hmid, int m, char* nonce)
             return i * 128;
         }
         int stop_=readStop();
+        if (stop_) {
+            return -i * 128 - 1;
+        }
+    }
+    return -i * 128 - 1;
+}
+
+long long int loop_cpu_AVX(
+    __m128i lmid[STATE_LENGTH], // mutable
+    __m128i hmid[STATE_LENGTH], // mutable
+    int mwm,
+    char nonce[HASH_LENGTH])    // mutable
+{
+    int n = 0, j = 0;
+    long long int i = 0;
+    __m128i lhcpy[2][2][STATE_LENGTH];
+
+    for (i = 0; !incr_AVX(lmid, hmid); i++) {
+        // init
+        memcpy(lhcpy[L_IDX], lmid, sizeof(__m128i) * STATE_LENGTH);
+        memcpy(lhcpy[H_IDX], hmid, sizeof(__m128i) * STATE_LENGTH);
+
+        transform64_AVX(lhcpy);
+        
+        if ((n = check_AVX(lhcpy[L_IDX][1], lhcpy[H_IDX][1], mwm)) >= 0) {
+            seri(lmid, hmid, n, nonce);
+            return i * 128;
+        }
+        int stop_ = readStop();
         if (stop_) {
             return -i * 128 - 1;
         }
@@ -431,19 +744,23 @@ void *pwork_(void* p)
     __m128i lmid[STATE_LENGTH], hmid[STATE_LENGTH];
 
     para(par->mid, lmid, hmid);
-    lmid[0] = _mm_set_epi64x(LOW00, LOW01);
-    hmid[0] = _mm_set_epi64x(HIGH00, HIGH01);
-    lmid[1] = _mm_set_epi64x(LOW10, LOW11);
-    hmid[1] = _mm_set_epi64x(HIGH10, HIGH11);
-    lmid[2] = _mm_set_epi64x(LOW20, LOW21);
-    hmid[2] = _mm_set_epi64x(HIGH20, HIGH21);
-    lmid[3] = _mm_set_epi64x(LOW30, LOW31);
-    hmid[3] = _mm_set_epi64x(HIGH30, HIGH31);
-    lmid[4] = _mm_set_epi64x(LOW40, LOW41);
-    hmid[4] = _mm_set_epi64x(HIGH40, HIGH41);
+    lmid[0] = _mm_set_epi64x(LO00, LO01);
+    hmid[0] = _mm_set_epi64x(HI00, HI01);
+    lmid[1] = _mm_set_epi64x(LO10, LO11);
+    hmid[1] = _mm_set_epi64x(HI10, HI11);
+    lmid[2] = _mm_set_epi64x(LO20, LO21);
+    hmid[2] = _mm_set_epi64x(HI20, HI21);
+    lmid[3] = _mm_set_epi64x(LO30, LO31);
+    hmid[3] = _mm_set_epi64x(HI30, HI31);
+    lmid[4] = _mm_set_epi64x(LO40, LO41);
+    hmid[4] = _mm_set_epi64x(HI40, HI41);
 
     incrN128(par->n, lmid, hmid);
-    par->count = loop_cpu(lmid, hmid, par->mwm, par->nonce);
+    if (hasAvx(par->n)) {
+        par->count = loop_cpu_AVX(lmid, hmid, par->mwm, par->nonce);
+    } else {
+        par->count = loop_cpu(lmid, hmid, par->mwm, par->nonce);
+    }
     if (par->count >= 0) {
         writeStop(1);
     }
@@ -560,11 +877,20 @@ void test()
     }
 
     int m = 18;
-    time_t start = time(NULL);
+
+    struct timeval start;	
+    gettimeofday(&start, NULL);
+
     long long int cnt = pwork(tx, m, nonce);
-    time_t end = time(NULL);
-    double dif = (double)(end - start);
-    printf("count=%lld kHash/sec: %lld \n", cnt, (long long int)((double)(cnt / 1e3) / dif));
+    
+    struct timeval end;	
+    gettimeofday(&end, NULL);
+
+    time_t diffsec = difftime(end.tv_sec, start.tv_sec);
+    suseconds_t diffsub = end.tv_usec - start.tv_usec;
+    double realsec = diffsec + diffsub * 1e-6;
+
+    printf("count=%lld sec=%8.6lf kHash/sec: %lld \n", cnt, realsec, (long long int)((double)(cnt / 1e3) / realsec));
 
     memcpy(trits + TX_LENGTH * 3 - HASH_LENGTH, nonce, HASH_LENGTH);
     memset(mid, 0, STATE_LENGTH);


### PR DESCRIPTION
## Resolved Issues
- close AidosKuneen/aidos-wallet#14

## Related Issues
- none

## Details of Changes
- Added AVX2 support in PoW processing 

## Testing
- It has been tested only on MacOS with CPUs that support AVX2.
The test was to verify that the result of the function test() matches the AVX2 ON/OFF, generate the address several times in mainnet and verify that it is available.
- Testing on Windows, Linux and CPUs that do not support AVX2 has not been possible because of the environment I do not own.
The change should be released after sufficient testing in these environments.
If you have an environment where testing is possible, please take action.

