### PR TITLE
BugFix : PoW multiplicity

### DIFF
--- a/ccurl/libccurl.cpp
+++ b/ccurl/libccurl.cpp
@@ -399,9 +399,9 @@ void para(char in[], __m128i l[], __m128i h[])
 void incrN128(int n, __m128i* mid_low, __m128i* mid_high)
 {
     int i, j;
-    alignas(16) unsigned long long c[2]={1,1};
     __m128i carry;
     for (j = 0; j < n; j++) {
+        alignas(16) unsigned long long c[2]={1,1};
         carry = _mm_set_epi64x(HBITS, HBITS);
         for (i = HASH_LENGTH - 7; i < HASH_LENGTH && c[0] ; i++) {
             __m128i low = mid_low[i], high = mid_high[i];


### PR DESCRIPTION
## Resolved Issues
- close AidosKuneen/aidos-wallet#17

## Related Issues
- AidosKuneen/aidos-wallet#14

## Details of Changes
- There is a problem where the multiplicity is not set correctly in the code to do PoW.

## Testing
- With the number of CPUs set to 1 and the test function running, we got similar results before and after the change.
- If you set the number of CPUs to 2 or more, you will get different results.
This result confirms that the multi-threaded operation worked correctly and resulted in faster PoW results.
